### PR TITLE
Palette and draw order fixes

### DIFF
--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -1438,10 +1438,14 @@ endif						;	   |
 	JSR CODE_B8CE99				;$B88B45   |
 	JSR CODE_B8CEBA				;$B88B48   |
 CODE_B88B4B:					;	   |
-	LDA #$0001				;$B88B4B   |
-	LDY $08A4				;$B88B4E   |
+	LDA #$0001				;$B88B4B   |	;Kong palette 1 (previously Diddy)
+;START OF PATCH (when crossing a No-Animal sign while transformed into an Animal Buddy, load/assign palette for active Kong based on kong_status and kong_palette_order instead of $08A4)
+	LDY kong_status
+	CPY kong_palette_order			;These will match if the leader Kong is using the first palette, and won't if using the second
+;	LDY $08A4				;$B88B4E   |
+;END OF PATCH
 	BEQ CODE_B88B56				;$B88B51   |
-	LDA #$0004				;$B88B53   |
+	LDA #$0004				;$B88B53   |	;Kong palette 2 (previously Dixie)
 CODE_B88B56:					;	   |
 	LDX $0593				;$B88B56   |
 	JSL CODE_BB8C44				;$B88B59   |

--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -1438,14 +1438,10 @@ endif						;	   |
 	JSR CODE_B8CE99				;$B88B45   |
 	JSR CODE_B8CEBA				;$B88B48   |
 CODE_B88B4B:					;	   |
-	LDA #$0001				;$B88B4B   |	;Kong palette 1 (previously Diddy)
-;START OF PATCH (when crossing a No-Animal sign while transformed into an Animal Buddy, load/assign palette for active Kong based on kong_status and kong_palette_order instead of $08A4)
-	LDY kong_status
-	CPY kong_palette_order			;These will match if the leader Kong is using the first palette, and won't if using the second
-;	LDY $08A4				;$B88B4E   |
-;END OF PATCH
+	LDA #$0001				;$B88B4B   |
+	LDY $08A4				;$B88B4E   |
 	BEQ CODE_B88B56				;$B88B51   |
-	LDA #$0004				;$B88B53   |	;Kong palette 2 (previously Dixie)
+	LDA #$0004				;$B88B53   |
 CODE_B88B56:					;	   |
 	LDX $0593				;$B88B56   |
 	JSL CODE_BB8C44				;$B88B59   |

--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -1438,10 +1438,14 @@ endif						;	   |
 	JSR CODE_B8CE99				;$B88B45   |
 	JSR CODE_B8CEBA				;$B88B48   |
 CODE_B88B4B:					;	   |
-	LDA #$0001				;$B88B4B   |
-	LDY $08A4				;$B88B4E   |
+	LDA #$0001				;$B88B4B   |	;Kong palette 1 (previously Diddy)
+;START OF PATCH (when crossing a No-Animal sign while transformed into an Animal Buddy, load/assign palette for active Kong based on kong_status and kong_palette_order instead of $08A4)
+	LDY kong_status				;-These will match if the leader Kong is using the first palette, and won't if using the second
+	CPY kong_palette_order			;/
+;	LDY $08A4				;$B88B4E   |
+;END OF PATCH
 	BEQ CODE_B88B56				;$B88B51   |
-	LDA #$0004				;$B88B53   |
+	LDA #$0004				;$B88B53   |	;Kong palette 2 (previously Dixie)
 CODE_B88B56:					;	   |
 	LDX $0593				;$B88B56   |
 	JSL CODE_BB8C44				;$B88B59   |

--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -5509,24 +5509,26 @@ kong_pal_order_check_done:
 ;Start of code to get palette attribute from follower Kong to be "replaced" by Kong released from DK Barrel
 	LDA $0012,y				;Load OAM attributes of old follower Kong
 	AND #$0E00				;Isolate palette bits
-	STA temp_32				;Store to temporary variable
+	STA temp_32				;Store to temporary variable $32
 ;End of code to to get palette attribute from follower Kong to be "replaced" by Kong released from DK Barrel
 	JSL update_kong_status_wrapper
 ;Start of code to swap palette attributes of old follower Kong with new follower Kong and load palettes
 	CPY $0597				;Compare to object address of new follower Kong
 	BEQ old_follower_kong_is_barrel_kong	;Skip ahead if equal
-	LDA temp_32
-	XBA
-	TAX
-	XBA
-	EOR $0012,y
-	STA $0012,y
-	LDA $0B64,x
-	STA temp_34
+	LDA temp_32				;Load palette bits of old follower Kong from temp variable
+	XBA					;Swap high and low bytes
+	TAX					;Transfer result to X
+	XBA					;Swap high and low bytes back again
+	EOR $0012,y				;Exclusive OR new follower Kong's OAM attributes to apply the other bits to the palette bits
+	STA $0012,y				;Store the result to the new follower Kong's OAM attributes
+	LDA $0B64,x				;$0B64,x is palette value in table to overwrite
+	STA temp_34				;Store this to temporary variable $34
 	LDA.w #global_sprite_palette
 	TYX
 	JSL CODE_BB8AE4	
-	LDY $0597
+	LDY $0597				;Y now contains new follower Kong's object entity table offset
+	LDA #$00D8				;#$00D8 is sprite order value normally used by the follower Kong, this fixes an issue where a suspended Kong would sometimes overlap the leader Kong)
+	STA $0002,y				;Store to new follower Kong's sprite order value
 	LDA $0012,y
 	AND #$0E00
 	EOR $0012,y
@@ -5553,20 +5555,20 @@ old_follower_kong_is_barrel_kong:
 ;Start of code to fix glitched state if the barrel breaks when teamed up
 	LDX $0593				;Load leader Kong's address into X
 	LDA $0D7A				;Load this variable to see if the leader is carrying something
-	BEQ .check_state		;If zero, we're not carrying a Kong, but still need to check some other states
+	BEQ .check_state			;If zero, we're not carrying a Kong, but still need to check some other states
 	CMP #$0F5A				;If not zero, check for first object slot after Kongs
-	BCC .reset_leader_state ;If value is less than this (which limits us to the Kongs being held), reset the leader's state
+	BCC .reset_leader_state 		;If value is less than this (which limits us to the Kongs being held), reset the leader's state
 .check_state:
 	LDA $2E,x				;Load leader Kong's state
 	CMP #$0020				;$0020 = Team throw (as leader)
-	BCC .do_not_reset_state	;If less than this value, stop checking (every status below this value would be caught by a check above, as $0D7A will be set to a Kong's object slot)
-	BEQ .reset_leader_state	;If matched, reset the state
+	BCC .do_not_reset_state			;If less than this value, stop checking (every status below this value would be caught by a check above, as $0D7A will be set to a Kong's object slot)
+	BEQ .reset_leader_state			;If matched, reset the state
 	CMP #$002C				;$002C = Team throw upward (as leader)
-	BEQ .reset_leader_state	;If matched, reset the state
+	BEQ .reset_leader_state			;If matched, reset the state
 	CMP #$002E				;$002E = Leader/thrower Kong moves to follower/thrown Kong's location
-	BEQ .reset_leader_state	;If matched, reset the state
+	BEQ .reset_leader_state			;If matched, reset the state
 	CMP #$007E				;$007E = Canceling team-up (as leader)
-	BNE .do_not_reset_state	;If not matched, don't reset the state
+	BNE .do_not_reset_state			;If not matched, don't reset the state
 .reset_leader_state:
 	LDA #$0001				;$0001 = falling
 	STA $2E,x				;Set Kong state
@@ -5574,7 +5576,7 @@ old_follower_kong_is_barrel_kong:
 	PHA
 	JSR CODE_B88092
 	LDA #$0007				;$0007 = base ID for falling animation
-	JSL CODE_B9D0B8			;Set Kong animation
+	JSL CODE_B9D0B8				;Set Kong animation
 	STZ $0D7A				;Clear object held pointer variable
 	BRA .do_not_push_current_sprite_to_stack
 .do_not_reset_state:

--- a/source/bank_B9.asm
+++ b/source/bank_B9.asm
@@ -2742,7 +2742,11 @@ CODE_B9DF7A:
 	CMP $0597				;$B9DF7A  \
 	BEQ CODE_B9DF9E				;$B9DF7D   |
 	LDA $08A4				;$B9DF7F   |
-	BEQ CODE_B9DF8A				;$B9DF82   |
+;START OF PATCH (sprite order fix for Donkey and Kiddy when jumping with a carried object)
+	CMP #$0001				;check if Dixie
+	BNE CODE_B9DF8A				;branch to skip setting carried object's sprite order if not Dixie
+	;BEQ CODE_B9DF8A			;$B9DF82   |
+;END OF PATCH
 	LDA #$0001				;$B9DF84   |
 	STA $0D80				;$B9DF87   |
 CODE_B9DF8A:					;	   |

--- a/source/bank_BE.asm
+++ b/source/bank_BE.asm
@@ -2034,12 +2034,11 @@ CODE_BEC694:					;	   |
 CODE_BEC695:
 ;START OF PATCH: Load palette for life icon
 	LDA $6E					;Non-zero if controlling an animal
-	BEQ .NotAnimal				;Zero means we are controlling Kongs
+	BEQ .NotRidingAnimal			;Zero means we are controlling Kongs
 	LDA $6C					;If a Kong is riding the animal, this is the pointer to the Kong object
-	BEQ .TransformedIntoAnimal		;Zero here means we are transformed into an animal via an Animal Buddy Barrel
-	TAX					;Reached if riding an animal
-	BRA .LoadAttributeUpper
-.TransformedIntoAnimal:
+	BNE .RidingAnimal			;Non-zero here means we are riding an animal
+.NotRidingAnimal:
+	;This code is reached if Kongs or transformed into an animal
 	LDA kong_status				;-These will match if the leader Kong is using the first palette, and won't if using the second
 	CMP kong_palette_order			;/
 	BNE .LoadSecondKongPalette
@@ -2048,13 +2047,14 @@ CODE_BEC695:
 .LoadSecondKongPalette:
 	LDA #$6574							;Load Kong palette 2 for life icon (previously Dixie)
 	BRA .SkipToAssigningPalette
-.NotAnimal:
-	LDX $0593				;Get leader Kong's object address
-.LoadAttributeUpper:
+.RidingAnimal:
+	;This code is reached if riding an animal
+	TAX
 	LDA $13,x				;Get upper bits of attribute in lower byte
 	AND #$000E				;Isolate these bits
 	TAX					;Transfer the accumulator to the X index register
 	LDA $0B64,x				;Retrieve palette address from table where they are stored
+.SkipToAssigningPalette:
 ;END OF PATCH
 	JSL CODE_BB8A65				;$BEC698   |
 	DEC $0B74,x				;$BEC69C   |		;Decrement number of references to this palette

--- a/source/bank_BE.asm
+++ b/source/bank_BE.asm
@@ -2032,23 +2032,31 @@ CODE_BEC694:					;	   |
 	RTL					;$BEC694  /
 
 CODE_BEC695:
-	;START OF PATCH: Load palette for life icon
+;START OF PATCH: Load palette for life icon
 	LDA $6E					;Non-zero if controlling an animal
-	BEQ .NotAnimal
+	BEQ .NotAnimal				;Zero means we are controlling Kongs
 	LDA $6C					;If a Kong is riding the animal, this is the pointer to the Kong object
-	BEQ .NotAnimal
-	TAX
+	BEQ .TransformedIntoAnimal		;Zero here means we are transformed into an animal via an Animal Buddy Barrel
+	TAX					;Reached if riding an animal
 	BRA .LoadAttributeUpper
+.TransformedIntoAnimal:
+	LDA kong_status				;-These will match if the leader Kong is using the first palette, and won't if using the second
+	CMP kong_palette_order			;/
+	BNE .LoadSecondKongPalette
+	LDA #$6484				;$BEC695  \		;Load Kong palette 1 for life icon (previously Diddy)
+	BRA .SkipToAssigningPalette
+.LoadSecondKongPalette:
+	LDA #$6574							;Load Kong palette 2 for life icon (previously Dixie)
+	BRA .SkipToAssigningPalette
 .NotAnimal:
 	LDX $0593				;Get leader Kong's object address
 .LoadAttributeUpper:
 	LDA $13,x				;Get upper bits of attribute in lower byte
 	AND #$000E				;Isolate these bits
-	TAX						;Transfer the accumulator to the X index register
+	TAX					;Transfer the accumulator to the X index register
 	LDA $0B64,x				;Retrieve palette address from table where they are stored
-	;LDA #$6484				;$BEC695  \			;Load Diddy's palette for life icon
-	;END OF PATCH: Load palette for life icon
-	JSL CODE_BB8A65			;$BEC698   |
+;END OF PATCH
+	JSL CODE_BB8A65				;$BEC698   |
 	DEC $0B74,x				;$BEC69C   |		;Decrement number of references to this palette
 	AND #$0E00				;$BEC69F   |		;Get palette bits from attribute word in accumulator
 	ORA #$3000				;$BEC6A2   |		;Set priority bits

--- a/source/bank_BE.asm
+++ b/source/bank_BE.asm
@@ -2032,23 +2032,32 @@ CODE_BEC694:					;	   |
 	RTL					;$BEC694  /
 
 CODE_BEC695:
-	;START OF PATCH: Load palette for life icon
+;START OF PATCH: Load palette for life icon
 	LDA $6E					;Non-zero if controlling an animal
-	BEQ .NotAnimal
+	BEQ .NotAnimal				;Zero means we are controlling Kongs
 	LDA $6C					;If a Kong is riding the animal, this is the pointer to the Kong object
-	BEQ .NotAnimal
+	BEQ .TransformedIntoAnimal		;Zero here means we are transformed into an animal via an Animal Buddy Barrel
 	TAX
 	BRA .LoadAttributeUpper
+.TransformedIntoAnimal:
+	LDA kong_status
+	CMP kong_palette_order			;These will match if the leader Kong is using the first palette, and won't if using the second
+	BNE .LoadSecondKongPalette
+	LDA #$6484				;$BEC695  \		;Load first Kong palette for life icon (previously Diddy)
+	BRA .SkipToAssigningPalette
+.LoadSecondKongPalette
+	LDA #$6574							;Load second Kong palette for life icon (previously Dixie)
+	BRA .SkipToAssigningPalette
 .NotAnimal:
 	LDX $0593				;Get leader Kong's object address
 .LoadAttributeUpper:
 	LDA $13,x				;Get upper bits of attribute in lower byte
 	AND #$000E				;Isolate these bits
-	TAX						;Transfer the accumulator to the X index register
+	TAX					;Transfer the accumulator to the X index register
 	LDA $0B64,x				;Retrieve palette address from table where they are stored
-	;LDA #$6484				;$BEC695  \			;Load Diddy's palette for life icon
-	;END OF PATCH: Load palette for life icon
-	JSL CODE_BB8A65			;$BEC698   |
+.SkipToAssigningPalette:
+;END OF PATCH: Load palette for life icon
+	JSL CODE_BB8A65				;$BEC698   |
 	DEC $0B74,x				;$BEC69C   |		;Decrement number of references to this palette
 	AND #$0E00				;$BEC69F   |		;Get palette bits from attribute word in accumulator
 	ORA #$3000				;$BEC6A2   |		;Set priority bits

--- a/source/bank_BE.asm
+++ b/source/bank_BE.asm
@@ -2032,32 +2032,23 @@ CODE_BEC694:					;	   |
 	RTL					;$BEC694  /
 
 CODE_BEC695:
-;START OF PATCH: Load palette for life icon
+	;START OF PATCH: Load palette for life icon
 	LDA $6E					;Non-zero if controlling an animal
-	BEQ .NotAnimal				;Zero means we are controlling Kongs
+	BEQ .NotAnimal
 	LDA $6C					;If a Kong is riding the animal, this is the pointer to the Kong object
-	BEQ .TransformedIntoAnimal		;Zero here means we are transformed into an animal via an Animal Buddy Barrel
+	BEQ .NotAnimal
 	TAX
 	BRA .LoadAttributeUpper
-.TransformedIntoAnimal:
-	LDA kong_status
-	CMP kong_palette_order			;These will match if the leader Kong is using the first palette, and won't if using the second
-	BNE .LoadSecondKongPalette
-	LDA #$6484				;$BEC695  \		;Load first Kong palette for life icon (previously Diddy)
-	BRA .SkipToAssigningPalette
-.LoadSecondKongPalette
-	LDA #$6574							;Load second Kong palette for life icon (previously Dixie)
-	BRA .SkipToAssigningPalette
 .NotAnimal:
 	LDX $0593				;Get leader Kong's object address
 .LoadAttributeUpper:
 	LDA $13,x				;Get upper bits of attribute in lower byte
 	AND #$000E				;Isolate these bits
-	TAX					;Transfer the accumulator to the X index register
+	TAX						;Transfer the accumulator to the X index register
 	LDA $0B64,x				;Retrieve palette address from table where they are stored
-.SkipToAssigningPalette:
-;END OF PATCH: Load palette for life icon
-	JSL CODE_BB8A65				;$BEC698   |
+	;LDA #$6484				;$BEC695  \			;Load Diddy's palette for life icon
+	;END OF PATCH: Load palette for life icon
+	JSL CODE_BB8A65			;$BEC698   |
 	DEC $0B74,x				;$BEC69C   |		;Decrement number of references to this palette
 	AND #$0E00				;$BEC69F   |		;Get palette bits from attribute word in accumulator
 	ORA #$3000				;$BEC6A2   |		;Set priority bits

--- a/source/bank_FF.asm
+++ b/source/bank_FF.asm
@@ -547,6 +547,7 @@ DATA_FF0A06:
 	dw !initcommand_set_animation, $01D2
 	dw !initcommand_success
 
+;Funky Kong cast roll init
 DATA_FF0A20:
 	dw sprite.number, $0318
 	dw sprite.x_position, $00E0
@@ -558,13 +559,17 @@ DATA_FF0A20:
 	dw !initcommand_set_animation, $01CA
 	dw !initcommand_success
 
+;Funky's surfboard cast roll init
 DATA_FF0A42:
 	dw sprite.number, $0318
 	dw sprite.x_position, $00E0
 	dw sprite.y_position, $0180
 	dw sprite.unknown_42, $0000
 	dw sprite.unknown_44, DATA_BAC28D
-	dw !initcommand_set_alt_palette, $0004
+;START OF PATCH (alter Funky surfboard in cast roll to use a unique palette instead of Dixie's)
+	dw !initcommand_set_alt_palette, $0025
+;	dw !initcommand_set_alt_palette, $0004
+;END OF PATCH
 	dw !initcommand_set_oam, $3000
 	dw !initcommand_set_animation, $01CB
 	dw !initcommand_success
@@ -2909,22 +2914,30 @@ DATA_FF24BC:
 	db $FF, $FF, $FF, $FF
 ;END OF PATCH
 
+;Swanky Kong object init
 DATA_FF24DE:
 	dw sprite.number, $018C
 	dw sprite.x_position, $0080
 	dw sprite.y_position, $00A0
-	dw sprite.render_order, $00F0
+;START OF PATCH (adjust Swanky's render order so that he appears behind the other Kongs)
+	dw sprite.render_order, $00CC
+;	dw sprite.render_order, $00F0
+;END OF PATCH
 	dw sprite.unknown_42, $0000
 	dw sprite.unknown_44, DATA_BAC2AB
 	dw !initcommand_set_oam, $2000
 	dw !initcommand_set_alt_palette, $0037
 	dw !initcommand_success
 
+;Swanky's tooth sparkle object init
 DATA_FF2500:
 	dw sprite.number, $018C
 	dw sprite.x_position, $0080
 	dw sprite.y_position, $00A0
-	dw sprite.render_order, $00F8
+;START OF PATCH (adjust render order of Swanky's tooth sparkle so it appears behind the other Kongs but still in front of Swanky)
+	dw sprite.render_order, $00D4
+;	dw sprite.render_order, $00F8
+;END OF PATCH
 	dw sprite.unknown_42, $0000
 	dw sprite.unknown_44, DATA_BAC2BD
 	dw sprite.unknown_1C, $C000


### PR DESCRIPTION
I've made a few commits to my fork over the past few days, and figured these should be merged before things get too far out of hand:
- The palette for the life counter is now properly assigned when transformed into an Animal Buddy.
- Draw order is now correct when Donkey and Kiddy jump while carrying an object (Issue #48).
- Draw order is now correct for Kongs released from a DK Barrel (Issue #51).
- Swanky's draw order has been adjusted so that he no longer overlaps the Kongs.
- The palette of Funky's surfboard is now correct in the Cast of Characters sequence.
- Palettes are now assigned correctly when transforming back into Kongs after crossing a No-Animal Sign.