### PR TITLE
Fixed a few Core Engine Stability related issues (#36, #54, #58)

### DIFF
--- a/source/bank_80.asm
+++ b/source/bank_80.asm
@@ -585,6 +585,17 @@ CODE_80876E:
 	STA $36					;$80877F   |
 	LDA #$00FE				;$808781   |
 	STA $38					;$808784   |
+;START OF PATCH (set Kong status for demo)
+	LDA.l $000605				;Load value of gameplay demo
+	CMP #$0003				;Compare to three (third demo in Parrot Chute Panic)
+	BEQ .demo_3				;If it matches, branch so that we can set Kong status differently
+	LDA #$0100				;Diddy/Dixie
+	BRA .set_kong_status
+.demo_3:
+	LDA #$0001				;Dixie/Diddy
+.set_kong_status:
+	STA kong_status
+;END OF PATCH
 	LDA $05FB				;$808786   |
 	CMP #$0001				;$808789   |
 	BNE CODE_8087B8				;$80878C   |

--- a/source/bank_B4.asm
+++ b/source/bank_B4.asm
@@ -1686,20 +1686,39 @@ CODE_B48DB5:
 CODE_B48DF9:					;	   |
 	RTS					;$B48DF9  /
 
+;START OF PATCH (add routine to set leader Kong to Diddy and follower Kong to the previous leader for ending sequences)
+set_diddy_to_1st_and_leader_to_2nd:
+	SEP #$20
+	LDA kong_status				;Load value of Kong in first slot
+	BEQ .first_kong_diddy			;Branch if Diddy id already the leader (zero flag set)
+	STA kong_status+1			;otherwise, move first Kong into second Kong slot
+	STZ kong_status				;and zero out first Kong slot (set to Diddy)
+	STZ $08A4				;Zero out $08A4 as well (Diddy is the active Kong)
+.first_kong_diddy:
+	REP #$20				;If Diddy is already the leader, just reset the CPU flags and return
+	RTS
+;END OF PATCH
+
 CODE_B48DFA:
 	JSL disable_screen			;$B48DFA  \
 	LDA #$0040				;$B48DFE   |
 	TSB $08FB				;$B48E01   |
 	LDA #$0040				;$B48E04   |
 	TRB $06A5				;$B48E07   |
-	LDA $08A4				;$B48E0A   |
+;START OF PATCH (fix two-Diddy issue in normal ending and subsequent write of Diddy/Diddy Kong status to SRAM; part 1 of 2)
+	LDA kong_status
+	;LDA $08A4				;$B48E0A   |
 	STA $0660				;$B48E0D   |
 	LDA $08C2				;$B48E10   |
 	STA $0676				;$B48E13   |
 	LDA #$4000				;$B48E16   |
 	TSB $08C2				;$B48E19   |
-	LDA #$0000				;$B48E1C   |
-	JSL CODE_808837				;$B48E1F   |
+	JSR set_diddy_to_1st_and_leader_to_2nd
+	LDA kong_status
+	JSL get_kong_spr_and_var_addrs_kong_fam_scr_global
+;	LDA #$0000				;$B48E1C   |
+;	JSL CODE_808837				;$B48E1F   |
+;END OF PATCH
 	STZ $0689				;$B48E23   |
 	JSR CODE_B48C9D				;$B48E26   |
 	LDX #$0000				;$B48E29   |
@@ -1927,7 +1946,10 @@ CODE_B49043:
 	LDA $0676				;$B49043  \
 	STA $08C2				;$B49046   |
 	LDA $0660				;$B49049   |
-	STA $08A4				;$B4904C   |
+;START OF PATCH (fix two-Diddy issue in normal ending and subsequent write of Diddy/Diddy Kong status to SRAM; part 2 of 2)
+	STA kong_status				;restore Kong status in preparation for Cranky's Video Game Heroes screen in ending
+;	STA $08A4				;$B4904C   |
+;END OF PATCH
 	LDA #CODE_808CD9			;$B4904F   |
 	STA NMI_pointer				;$B49052   |
 	LDA #CODE_B4BEEF			;$B49054   |
@@ -2027,10 +2049,19 @@ CODE_B49122:
 	JML restart_rareware_logo		;$B49122  |
 
 CODE_B49126:
+;START OF PATCH (fix two-Diddy issue in secret ending and subsequent write of Diddy/Diddy Kong status to SRAM; part 1 of 2)
+	LDA kong_status
+	STA $0660
+	LDA $08C2
+	STA $0676
 	LDA #$4000				;$B49126  \
 	TSB $08C2				;$B49129   |
-	LDA #$0000				;$B4912C   |
-	JSL CODE_808837				;$B4912F   |
+	JSR set_diddy_to_1st_and_leader_to_2nd
+	LDA kong_status
+	JSL get_kong_spr_and_var_addrs_kong_fam_scr_global
+;	LDA #$0000				;$B4912C   |
+;	JSL CODE_808837				;$B4912F   |
+;END OF PATCH
 	STZ $0689				;$B49133   |
 	JSR CODE_B48C9D				;$B49136   |
 	LDX #$0000				;$B49139   |
@@ -2065,7 +2096,10 @@ CODE_B49188:
 	LDA $0676				;$B49188  \
 	STA $08C2				;$B4918B   |
 	LDA $0660				;$B4918E   |
-	STA $08A4				;$B49191   |
+;START OF PATCH (fix two-Diddy issue in secret ending and subsequent write of Diddy/Diddy Kong status to SRAM; part 2 of 2)
+	STA kong_status
+;	STA $08A4				;$B49191   |
+;END OF PATCH
 	LDA #CODE_808CD9			;$B49194   |
 	STA NMI_pointer				;$B49197   |
 	LDA #CODE_B4BEEF			;$B49199   |

--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -8,52 +8,53 @@ else
 	db $B3, $DE, $12, $29
 endif
 
+;Jump table for various Kong-to-object interaction routines (RAM address $0A82)
 DATA_B88004:
-	dw CODE_B89197
-	dw CODE_B89220
-	dw CODE_B8852B
-	dw CODE_B8842B
-	dw CODE_B8848E
-	dw CODE_B884EC
-	dw CODE_B88623
-	dw CODE_B885B8
-	dw CODE_B8871B
-	dw CODE_B8865B
-	dw CODE_B8811E
-	dw CODE_B880D2
-	dw CODE_B89385
-	dw CODE_B88755
-	dw CODE_B89385
-	dw CODE_B89385
-	dw CODE_B886F3
-	dw CODE_B8869E
-	dw CODE_B89319
-	dw CODE_B8934A
-	dw CODE_B881E9
-	dw CODE_B88228
-	dw CODE_B893AA
-	dw CODE_B894C2
-	dw CODE_B88B15
-	dw CODE_B8874D
-	dw CODE_B887D2
-	dw CODE_B8857E
-	dw CODE_B88911
-	dw CODE_B88929
-	dw CODE_B885D5
-	dw CODE_B88A4C
-	dw CODE_B88A92
-	dw CODE_B88C9D
-	dw CODE_B88CA3
-	dw CODE_B8815F
-	dw CODE_B885F5
-	dw CODE_B8899C
-	dw CODE_B88269
-	dw CODE_B88340
-	dw CODE_B88379
-	dw CODE_B88864
-	dw CODE_B89385
-	dw CODE_B88421
-	dw CODE_B8841C
+	dw CODE_B89197	;0001: Swapping in water
+	dw CODE_B89220	;0002: Swapping on land
+	dw CODE_B8852B	;0003: Rejoining team-up after throwing partner upwards
+	dw CODE_B8842B	;0004: Initiating team-up
+	dw CODE_B8848E	;0005: Teamed up
+	dw CODE_B884EC	;0006: Canceling team-up
+	dw CODE_B88623	;0007: Getting stuck to honey on ground
+	dw CODE_B885B8	;0008: Getting stuck to honey on wall
+	dw CODE_B8871B	;0009: 14
+	dw CODE_B8865B	;000A: 16
+	dw CODE_B8811E	;000B: Stunned by enemy on ground (Kudgel)
+	dw CODE_B880D2	;000C: 1A
+	dw CODE_B89385	;000D: 1C
+	dw CODE_B88755	;000E: Bouncing off of tire
+	dw CODE_B89385	;000F: 20
+	dw CODE_B89385	;0010: Entering barrel/cannon
+	dw CODE_B886F3	;0011: Grabbing horizontal rope
+	dw CODE_B8869E	;0012: Grabbing vertical rope
+	dw CODE_B89319	;0013: 28
+	dw CODE_B8934A	;0014: 2A
+	dw CODE_B881E9	;0015: Mounting skull cart
+	dw CODE_B88228	;0016: Jumping off skull cart
+	dw CODE_B893AA	;0017: Mounting Animal Buddy
+	dw CODE_B894C2	;0018: Dismounting Animal Buddy
+	dw CODE_B88B15	;0019: Transforming Animal Buddy into item (crossing No-Animal sign)
+	dw CODE_B8874D	;001A: 36
+	dw CODE_B887D2	;001B: Defeating enemy by stomping
+	dw CODE_B8857E	;001C: Defeating enemy by rolling
+	dw CODE_B88911	;001D: Defeating enemy by team throw
+	dw CODE_B88929	;001E: Knocked back by enemy
+	dw CODE_B885D5	;001F: Stunned by K. Rool before being hit by his blunderbuss
+	dw CODE_B88A4C	;0020: 42
+	dw CODE_B88A92	;0021: 44
+	dw CODE_B88C9D	;0022: 46
+	dw CODE_B88CA3	;0023: Hurt by enemy/obstacle
+	dw CODE_B8815F	;0024: Frozen by K. Rool's blue gas cloud
+	dw CODE_B885F5	;0025: Slowed down by K. Rool's red gas cloud/reversed by K. Rool's purple gas cloud
+	dw CODE_B8899C	;0026: Hurt by being hit by K. Rool's blunderbuss
+	dw CODE_B88269	;0027: Collecting Kremkoin
+	dw CODE_B88340	;0028: 52
+	dw CODE_B88379	;0029: Falling into pit
+	dw CODE_B88864	;002A: Hitting goal target
+	dw CODE_B89385	;002B: Walking through an entrance/running off screen after hitting target
+	dw CODE_B88421	;002C: 5A
+	dw CODE_B8841C	;002D: Leaving level
 
 CODE_B8805E:
 	LDA $08C2				;$B8805E  \
@@ -72,6 +73,7 @@ CODE_B8806A:
 	JSR CODE_B8D8BE				;$B88078   |
 	BRA CODE_B88066				;$B8807B  /
 
+;Routine for objects the Kongs interact with?
 CODE_B8807D:
 	PHK					;$B8807D  \
 	PLB					;$B8807E   |
@@ -1101,8 +1103,12 @@ CODE_B8889A:					;	   |
 	ORA $0AB8				;$B888AC   |
 	STA $0AB8				;$B888AF   |
 	JSR CODE_B88092				;$B888B2   |
-	LDA #$009E				;$B888B5   |
-	ORA $30,x				;$B888B8   |
+;START OF PATCH (disable collision with barrel cannons after hitting a goal target)
+	LDA #$0088				;-This will toggle bits #$0080 (invulnerability to enemies; normally clear) and #$0008 (enable collision with barrel cannons; normally set)
+	EOR $30,x				;/
+;	LDA #$009E				;$B888B5   |
+;	ORA $30,x				;$B888B8   |
+;END OF PATCH
 	STA $30,x				;$B888BA   |
 	LDA $0006,y				;$B888BC   |
 	AND #$FFFB				;$B888BF   |


### PR DESCRIPTION
- After defeating K. Rool in either K. Rool Duel or Krocodile Kore, the game now autosaves the proper kong_status value.  In the Monkey Museum scenes of both endings, things are handled a bit differently than anything else in this hack so far.  Since Cranky speaks to Diddy directly in his dialogue, he always appears in this scene as in the vanilla game. However, instead of Dixie, the second Kong is the one who was being controlled at the end of the battle.  If this was already Diddy, the second Kong will be the last one who was following in the battle. (Fix for Issue #36)

- When hitting a goal target, bits in the active Kong's object variable $30 were already manipulated to set invulnerability to enemies.  It happens that another bit in the same variable determines whether collision with Barrel Cannons is enabled.  This fix alters only two bytes in the ROM! (Fix for Issue #54)

- Added a few lines of code to set the Kong status variable so that the gameplay demos can play properly.  As an added bonus, the active Kong for the Parrot Chute Panic demo is now set to Dixie instead of Diddy because the demo seems to have originally been recorded using her.   That demo lasts slightly longer as a result, as it doesn't end by dying to a Zinger. (Fix for Issue #58)