### PR TITLE
Fix for Issue #71 and implemented more Kong-specific sounds

### DIFF
--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -544,9 +544,13 @@ CODE_B88421:
 CODE_B8842B:
 	JSR CODE_B8C87C				;$B8842B  \
 	BCS CODE_B8848D				;$B8842E   |
-	LDX #sound(5, !sound_team_up_mount_animal)	;$B88430   |	Team-up sound is Kong-specific, but set to the same ID for both
+;START OF PATCH (change one possible sound to Donkey Kong's for teaming up, and change entry point to subroutine)
+	LDX #sound(5, !sound_donkey_team_up_mount_aml)
+;	LDX #sound(5, !sound_team_up_mount_animal)	;$B88430   |	Team-up sound is Kong-specific, but set to the same ID for both
 	LDY #sound(5, !sound_team_up_mount_animal)	;$B88433   |
-	JSR CODE_B89186				;$B88436   |
+	JSR play_kong_sound_follower
+;	JSR CODE_B89186				;$B88436   |
+;END OF PATCH
 	LDA $0597				;$B88439   |
 	STA $0D7A				;$B8843C   |
 	STZ $0D7C				;$B8843F   |
@@ -2242,14 +2246,33 @@ CODE_B89182:
 	JSR CODE_B89186				;$B89182  \
 	RTL					;$B89185  /
 
+;START OF PATCH (add global wrapper, alternate starting point for CODE_B89186 to check for the follower kong instead of the leader)
+play_kong_snd_follower_global:
+	JSR play_kong_sound_follower
+	RTL
+
+play_kong_sound_follower:
+	LDA kong_status				;Load values of Kongs not in stasis
+	XBA					;Swap upper and lower bytes (lower byte will contain follower Kong value)
+	BRA play_kong_sound_common
+
 CODE_B89186:
-	LDA $08A4				;$B89186  \ current kong number
-	BEQ CODE_B89191				;$B89189   | if current kong is diddy
+;START OF PATCH (change code to load kong_status instead of $08A4, and check Donkey instead of Diddy)
+	LDA kong_status				;Load values of Kongs not in stasis
+play_kong_sound_common:
+	AND #$00FF				;Clear the upper 8 bits
+	CMP #$0002				;Compare value to $02 (Donkey)
+;	LDA $08A4				;$B89186  \ current kong number
+;END OF PATCH
+	BEQ CODE_B89191				;$B89189   | if current kong is donkey (previously diddy)
+;START OF PATCH (add label for possible branch destination of play_follower_kong_sound routine below)
+transfer_non_donkey_sound:
+;END OF PATCH
 	TYA					;$B8918B   | otherwise use value in y as sound effect number
 	JSL queue_sound_effect			;$B8918C   | play sound
 	RTS					;$B89190  /
 
-;if diddy is playing
+;if donkey is playing (previously diddy)
 CODE_B89191:
 	TXA					;$B89191  \ use value in x as sound effect number
 	JSL queue_sound_effect			;$B89192   | play sound
@@ -2295,9 +2318,13 @@ CODE_B891A0:
 	STA $2E,x				;$B891EE   |
 	LDA #$0043				;$B891F0   |
 	JSL CODE_B9D0B8				;$B891F3   |
-	LDX #sound(5, !sound_swap_kongs)	;$B891F7   |	Swap Kongs sound is Kong-specific, but set to the same ID for both
+;START OF PATCH (change one possible sound to Donkey Kong's for swapping underwater, and change entry point to subroutine)
+	LDX #sound(5, !sound_swap_to_donkey)
+;	LDX #sound(5, !sound_swap_kongs)	;$B891F7   |	Swap Kongs sound is Kong-specific, but set to the same ID for both
 	LDY #sound(5, !sound_swap_kongs)	;$B891FA   |
-	JSR CODE_B89186				;$B891FD   |
+	JSR play_kong_sound_follower
+;	JSR CODE_B89186				;$B891FD   |
+;END OF PATCH
 	RTS					;$B89200  /
 
 CODE_B89201:
@@ -2440,9 +2467,11 @@ else						;	   |
 endif						;	   |
 	JSR CODE_B8D1E8				;$B89308   |
 	JSL CODE_BB8C19				;$B8930B   |
+;START OF PATCH (disable play sound for kong swap (now handled by animation scripts)
 	;LDX #sound(5, !sound_swap_kongs)	;$B8930F   |	Swap Kongs sound is Kong-specific, but set to the same ID for both
 	;LDY #sound(5, !sound_swap_kongs)	;$B89312   |
-	;JSR CODE_B89186			;$B89315   |	disable play sound for kong swap (now handled by animation scripts)
+	;JSR CODE_B89186			;$B89315   |
+;END OF PATCH
 	RTS					;$B89318  /
 
 CODE_B89319:
@@ -2521,7 +2550,10 @@ CODE_B893AA:
 
 CODE_B893B0:
 	JSR CODE_B8939C				;$B893B0  \
-	LDX #sound(5, !sound_team_up_mount_animal)	;$B893B3   |	Mount animal sound is Kong-specific, but set to the same ID for both
+;START OF PATCH (change one possible sound to Donkey Kong's for mounting an animal)
+	LDX #sound(5, !sound_donkey_team_up_mount_aml)
+;	LDX #sound(5, !sound_team_up_mount_animal)	;$B893B3   |	Mount animal sound is Kong-specific, but set to the same ID for both
+;END OF PATCH
 	LDY #sound(5, !sound_team_up_mount_animal)	;$B893B6   |
 	JSR CODE_B89186				;$B893B9   |
 	STZ $0AEE				;$B893BC   |

--- a/source/bank_BE.asm
+++ b/source/bank_BE.asm
@@ -1361,14 +1361,18 @@ CODE_BEC1C2:
 
 CODE_BEC1CD:
 ;START OF PATCH (no click clack knockback for big kongs)
-	LDA $08A4
-	AND #$0002
-	BEQ .not_big
-	LDA #$001B
+	LDY current_sprite
+	LDA.w sprite.number,y			;Load object's type
+	CMP #$01DC				;Check if Click-Clack
+	BNE .normal_knockback			;Branch to normal knockback behavior if not
+	LDA $08A4				;Otherwise, load value of leader Kong
+	AND #$0002				;Bit $0002 is set if Donkey or Kiddy
+	BEQ .normal_knockback			;If not one of the big Kongs, branch to normal knockback behavior
+	LDA #$001B				;Kong-to-object interaction: Defeating enemy by stomping
 	BRL CODE_BEC52D
-.not_big:
+.normal_knockback:
 ;END OF PATCH
-	LDA #$001E				;$BEC1CD  \
+	LDA #$001E				;$BEC1CD  \	Kong-to-object interaction: Knocked back by enemy
 	BRL CODE_BEC52D				;$BEC1D0  /
 
 CODE_BEC1D3:

--- a/source/kong_hack/sound/sound_effects/ship_hold_sfx_data.asm
+++ b/source/kong_hack/sound/sound_effects/ship_hold_sfx_data.asm
@@ -1,0 +1,205 @@
+;Sound Effects: Ship Hold
+;32F2F1
+ship_hold_sfx_data:
+;	dw !dyn_snd_loc, $0134
+;If modifying this file, comment out the line above and uncomment the line below
+	dw !dyn_snd_loc, ((.end-.start)+((.end-.start)&$0001))>>1
+
+.start:
+arch spc700
+base !dyn_snd_loc
+	dw (.pointers_end-.pointers_start)>>1	;quantity of sound effects (default $0017)
+;sound effect pointers
+.pointers_start:
+	dw .seq_30EE	;60: Splash
+	dw .seq_30E4	;61: Splash (deeper)
+	dw .seq_30CD	;62: Kong jumping into water
+	dw .seq_30BB	;63: Clapper barking
+	dw .nothing	;64: -Nothing-
+	dw .seq_30A2	;65: Enguarde bill attack
+	dw .seq_2FA2	;66: Enguarde hit
+	dw .nothing	;67: -Nothing-
+	dw .seq_3035	;68: Flotsam moving
+	dw .seq_3018	;69: Puftup puffing up
+	dw .seq_2FE1	;6A: Puftup bursting (twinkle removed)
+	dw .seq_2FB6	;6B: Kong paddling
+	dw .seq_3072	;6C: Shuri spinning
+	dw .seq_305F	;6D: Clapper clapping/hurt by lava (Lava Lagoon)
+	dw .seq_3052	;6E: Clapper spitting ice
+.pointers_end:
+
+.seq_2FA2:
+	db !set_instrument, $06
+	db !set_vol_single_val, $46
+	db !set_adsr, $8F, $E0
+	db !vibrato_with_delay, $03, $02, $17, $01
+	db !echo_on
+	db $86, $06
+	db $80, $02
+	db $86, $14
+.nothing:
+	db !end_sequence
+
+.seq_2FB6:
+	db !echo_on
+	db !set_instrument, $DA
+	db !set_adsr, $F8, $E0
+	db !set_vol_single_val, $5A
+	db $8C, $08
+	db $8D, $08
+	db $8E, $08
+	db $8F, $05
+	db $90, $05
+	db !set_vol_single_val, $21
+	db $8E, $08
+	db $8F, $05
+	db $90, $05
+	db !set_vol_single_val, $16
+	db $8E, $08
+	db $8F, $05
+	db $90, $05
+	db !set_vol_single_val, $0B
+	db $8E, $08
+	db $8F, $05
+	db $90, $05
+	db !end_sequence
+
+.seq_2FE1:
+	db !set_adsr, $86, $E0
+	db !set_instrument, $0A
+	db !pitch_slide_up, $00, $02, $0B, $0B, $02
+	db !set_vol_single_val, $64
+	db $81, $10
+	db !set_adsr, $8F, $E0
+	db !set_vol_single_val, $6E
+	db $8A, $18
+	db !end_sequence
+
+.seq_3018:
+	db !set_instrument, $0A
+	db !set_vol_single_val, $7F
+	db !set_adsr, $86, $E0
+	db !pitch_slide_up, $00, $03, $21, $21, $02
+	db !set_vol_single_val, $7F
+	db !set_default_duration, $1E
+	db $81
+	db !set_vol_single_val, $1E
+	db $81
+	db !set_vol_single_val, $14
+	db $81
+	db !set_vol_single_val, $0A
+	db $81
+	db !default_duration_off
+	db !end_sequence
+
+.seq_3035:
+	db !set_instrument, $99
+	db !change_instr_pitch, $F8
+	db !fine_tune, $FC
+	db !echo_on
+	db !set_adsr, $87, $C1
+	db !set_vol_single_val, $50
+	db $96, $30
+	db !set_vol_single_val, $3C
+	db $96, $30
+.loop_point_3047:
+	db !set_vol_single_val, $28
+	db $96, $30
+	db !set_vol_single_val, $14
+	db $96, $30
+	db !jump_to_sequence : dw .loop_point_3047
+
+.seq_3052:
+	db !set_instrument, $43
+	db !noise_on
+	db !dsp_flag, $1A
+	db !set_vol_single_val, $08
+	db !set_adsr, $8B, $CF
+	db $8D, $38
+	db !end_sequence
+
+.seq_305F:
+	db !set_instrument, $0A
+	db !set_adsr, $8F, $E0
+	db !set_vol_single_val, $0C
+	db $9B, $02
+	db !echo_on
+	db !set_vol_single_val, $28
+	db $9B, $08
+	db !set_vol_single_val, $08
+	db $9B, $08
+	db !end_sequence
+
+.seq_3072:
+	db !set_instrument, $99
+	db !change_instr_pitch, $F8
+	db !fine_tune, $FC
+	db !echo_on
+	db !set_vol_single_val, $3A
+	db !set_adsr, $88, $E1
+	db !set_default_duration, $0E
+	db $A6
+	db $A8
+	db $A6
+	db $A8
+	db $A6
+	db $A8
+	db $A6
+	db $A8
+	db !default_duration_off
+	db !end_sequence
+
+.seq_30A2:
+	db !set_instrument, $50
+	db !set_adsr, $88, $C0
+	db !pitch_slide_up, $00, $01, $26, $44, $03
+	db !set_vol_single_val, $28
+	db $9A, $10
+	db !set_vol_single_val, $10
+	db $9A, $10
+	db !set_vol_single_val, $08
+	db $9A, $10
+	db !end_sequence
+
+.seq_30BB:
+	db !set_instrument, $CD
+	db !set_vol_single_val, $64
+	db !set_adsr, $8F, $E0
+	db $8B, $11
+	db !set_vol_single_val, $1E
+	db $8B, $11
+	db !set_vol_single_val, $0A
+	db $8B, $11
+	db !end_sequence
+
+.seq_30CD:
+	db !set_instrument, $99
+	db !change_instr_pitch, $F8
+	db !fine_tune, $FC
+	db !echo_on
+	db !set_adsr, $8F, $F1
+	db !set_vol_single_val, $7F
+	db $A0, $1A
+	db !set_vol_single_val, $2A
+	db $A0, $1A
+	db !set_vol_single_val, $0E
+	db $A0, $1A
+	db !end_sequence
+
+.seq_30E4:
+	db !set_instrument, $94
+	db !set_vol_single_val, $7F
+	db !set_adsr, $8F, $EE
+	db $8E, $50
+	db !end_sequence
+
+.seq_30EE:
+	db !set_instrument, $94
+	db !set_vol_single_val, $78
+	db !set_adsr, $8F, $F2
+	db $92, $30
+	db !end_sequence
+
+base off
+arch 65816
+.end:

--- a/source/kong_hack/sound/sound_effects/ship_ice_ending_sfx_data.asm
+++ b/source/kong_hack/sound/sound_effects/ship_ice_ending_sfx_data.asm
@@ -1,4 +1,4 @@
-;Sound Effects: Ship Deck/2, Ship Hold, Ice, Rigging, Credits, Secret Ending
+;Sound Effects: Ship Deck/2, Ice, Rigging, Credits, Secret Ending
 ;32F2F1
 ship_ice_ending_sfx_data:
 ;	dw !dyn_snd_loc, $0134

--- a/source/sound.asm
+++ b/source/sound.asm
@@ -2196,7 +2196,10 @@ DATA_EE117B:
 	dl lava_castle_boss_2_sfx_data			;0D
 	dl roller_coaster_sfx_data			;0E
 	dl swamp_forest_mine_brambles_hive_sfx_data	;0F
-	dl ship_ice_ending_sfx_data			;10
+;START OF PATCH (change which sound effect block is loaded with Ship Hold song)
+	dl ship_hold_sfx_data				;10
+;	dl ship_ice_ending_sfx_data			;10
+;END OF PATCH
 	dl dummy_sfx_data				;11
 	dl ship_ice_ending_sfx_data			;12
 	dl boss_1_sfx_data				;13
@@ -4158,8 +4161,10 @@ DATA_F2E72C:
 ;END OF PATCH
 	incsrc "data/sound/sound_effects/lava_castle_boss_2_sfx_data.asm"
 
-;START OF PATCH (add sound effect block for menus, remove placeholder sound effect blocks)
+;START OF PATCH (add sound effect blocks for menus and ship hold, remove placeholder sound effect blocks)
 	incsrc "kong_hack/sound/sound_effects/menus_sfx_data.asm"
+	incsrc "kong_hack/sound/sound_effects/ship_hold_sfx_data.asm"
+
 ;DATA_F2FB66:
 ;	dw !dyn_snd_loc, $0002		;Unused placeholder for song-specific sound effect set $08
 


### PR DESCRIPTION
Before checking if the current Kong should have knockback applied to them. CODE_BEC1CD now checks if the type of object being interacted with is $01DC (Click-Clack).  If not, knockback will always be applied.

The actions that Kong-specific sounds have been added for include teaming up, mounting an Animal Buddy, and swapping underwater.

Additionally, the Ship Hold music set has been given its own unique sound effect block to address an issue with Puftup's bursting sfx in Glimmer's Galleon.  This sfx has a portion that uses a twinkling sample, which is normally only heard in ice levels.  Sound engine modifications apparently resulted in a glitched version of this twinkling sound being audible in the Ship Hold levels as well (since the sample isn't loaded there).