### PR TITLE
Fix for issue #63

### DIFF
--- a/source/bank_B5.asm
+++ b/source/bank_B5.asm
@@ -6980,7 +6980,10 @@ CODE_B5C800:
 
 CODE_B5C80D:
 	LDA current_sprite			;$B5C80D  \
-	LDA #$0E40				;$B5C80F   |
+;START OF PATCH (Fix for Donkey and Kiddy having collision with kart tracks)
+	;LDA #$0E40				;$B5C80F   |
+	LDA #$0EFC
+;END OF PATCH
 	CMP current_sprite			;$B5C812   |
 	BCC CODE_B5C82C				;$B5C814   |
 	JSL CODE_B5C82C				;$B5C816   |


### PR DESCRIPTION
The code previously used 0E40 to compare with current_sprite and determine if the sprite would pass through the tracks or not. Changing it to 0EFC (Kiddy's slot) fixes the issue.