### PR TITLE
Fix for issues #66 , #72 , #74 and #80

### DIFF
--- a/source/bank_B3.asm
+++ b/source/bank_B3.asm
@@ -2551,7 +2551,7 @@ update_kong_barrel_number:
 	BEQ .active_diddy_overflow
 	LDA kong_status
 	XBA
-	AND #$00FF
+	AND #$FF00
 	BEQ .active_diddy_overflow
 
 .no_diddy_overflow

--- a/source/bank_B8.asm
+++ b/source/bank_B8.asm
@@ -2931,11 +2931,25 @@ npc_area_check:
 	PHX
 	LDX NMI_pointer
 	CPX #CODE_808CD9	;NMI for Cranky's Video Game Heroes and the Monkey Museum ending screens
-	BNE .is_false
+	;BNE .is_false  (this was causing the check_gamemode_submode branch to never be taken)
+	BNE .check_gamemode_submode
 .is_true:
+	;check if we have an extra kong or not
+	LDA $08C2
+	AND $4000
+	BEQ .mute_hidden_kong
+
+.set_carry:
 	PLX
 	SEC
 	RTS
+
+;STZ the hidden kong's animation number to stop them from playing idle sounds
+.mute_hidden_kong:
+	LDX $0597
+	STZ $36,x
+	BRA .set_carry
+
 .check_gamemode_submode:
 	LDX gamemode_submode
 	CPX #$000B		;Check if in submap (Should cover all Kong Family areas/Klubba's Kiosk, as gamemode_submode isn't changed when entering these areas)

--- a/source/data/levels/objects/screechs_sprint_objects.asm
+++ b/source/data/levels/objects/screechs_sprint_objects.asm
@@ -29,7 +29,10 @@
 %sprite($0001, $05B0, $01A6, $0592)
 %sprite($0001, $05B1, $01D2, $070A)
 %sprite($0001, $05B2, $017A, $058C)
-%sprite($0002, $0660, $09E0, $0C7C)
+;START OF PATCH (Fix for kloak crash)
+%sprite($00062, $0660, $09E0, $0C7C) ;(change param to 62 to make him spawn/throw kaboom earlier)
+;%sprite($0002, $0660, $09E0, $0C7C)
+;END OF PATCH
 %sprite($0101, $06BF, $0A48, $09B2)
 %sprite($0001, $06CE, $063C, $070A)
 %sprite($0001, $06CF, $0694, $0590)

--- a/source/kong_hack/objects/animations/swap_animations.asm
+++ b/source/kong_hack/objects/animations/swap_animations.asm
@@ -233,8 +233,9 @@ dixie_swap_to_kiddy_animation:
 	db $03 : dw $3DB0
 	db $03 : dw $3DB4
 	db $03 : dw $3DB8
-	db $03 : dw $3DBC
 	db !animation_command_81 : dw swap_kong_render_order
+	db $03 : dw $3DBC
+	;db !animation_command_81 : dw swap_kong_render_order
 kiddy_swap_dkc3_loop:
 	db $03 : dw $3D80
 	db $03 : dw $3D84
@@ -460,8 +461,9 @@ diddy_swap_to_kiddy_animation:
 	db $03 : dw $3DB0
 	db $03 : dw $3DB4
 	db $03 : dw $3DB8
-	db $03 : dw $3DBC
 	db !animation_command_81 : dw swap_kong_render_order
+	db $03 : dw $3DBC
+	;db !animation_command_81 : dw swap_kong_render_order
 	db !animation_command_82 : dw kiddy_swap_dkc3_loop
 	db !animation_command_80, $00
 


### PR DESCRIPTION
#66 : The issue happens because the klingers on the right are connected and all spawn at once. To fix this, the Kloak's parameter was changed to make him spawn earlier, thus throwing the kaboom before the klingers spawn and avoiding the crash.

#72: STZ'd the hidden follower kong's animation number ($36,x) to in turn stop them from playing idle sounds.

#74: Temporary fix, changing AND #$00FF to FF00 after the XBA fixed the issue, although im not sure if it has side effects. Tested it for a world 1 playthrough and everything was fine.

#80 : The code to swap kong render orders wasn't being called half of the time under the circumstances mentioned in the issue description. Moving it to happen one animation command earlier fixes this.